### PR TITLE
test: Update Should_Add_New_Message to be asynchronous

### DIFF
--- a/src/RazorPagesProject.E2ETests/IndexPageTest.cs
+++ b/src/RazorPagesProject.E2ETests/IndexPageTest.cs
@@ -20,7 +20,7 @@ public class IndexPageTest : IClassFixture<EdgeFixture>
     }
 
     [Fact]
-    public void Should_Add_New_Message()
+    public async Task Should_Add_New_Message()
     {
         // Arrange
         var newMessage = Guid.NewGuid().ToString();
@@ -29,6 +29,8 @@ public class IndexPageTest : IClassFixture<EdgeFixture>
         _topPage.NewMessage.Clear();
         _topPage.NewMessage.SendKeys(newMessage);
         _topPage.ClickAddMessageButton();
+
+        await Task.Delay(300);
 
         // Assert
         var message = _topPage.Messages.SingleOrDefault(m => m.Text == newMessage);


### PR DESCRIPTION
This pull request includes changes to the `IndexPageTest` class in the `src/RazorPagesProject.E2ETests` project to improve the handling of asynchronous operations. The most important changes include updating the test method to be asynchronous and adding a delay to ensure proper message handling.

Changes to improve asynchronous operations:

* [`src/RazorPagesProject.E2ETests/IndexPageTest.cs`](diffhunk://#diff-4f16e2d122e9a7e5e38a3446b11dfac95dab38bdbe4c27492f1449f5335ac776L23-R23): Updated the `Should_Add_New_Message` method to be asynchronous by changing its signature to `public async Task Should_Add_New_Message()`.
* [`src/RazorPagesProject.E2ETests/IndexPageTest.cs`](diffhunk://#diff-4f16e2d122e9a7e5e38a3446b11dfac95dab38bdbe4c27492f1449f5335ac776R33-R34): Added a delay of 300 milliseconds in the `Should_Add_New_Message` method to ensure the new message is properly handled before the assertion.