### PR TITLE
Update global.json and apply workarounds for E2E tests/Static Assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
 
     - name: Run web app and E2E tests
       run: |
+        $env:CI="true"
         dotnet run --project ./src/RazorPagesProject/RazorPagesProject.csproj --no-build &
         dotnet test ./src/RazorPagesProject.E2ETests
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,9 @@ jobs:
       run: dotnet test --no-build
 
     - name: Run web app and E2E tests
+      env:
+        CI: true
       run: |
-        $env:CI="true"
         dotnet run --project ./src/RazorPagesProject/RazorPagesProject.csproj --no-build &
         dotnet test ./src/RazorPagesProject.E2ETests
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.201",
+    "version": "9.0.300",
     "rollForward": "latestFeature"
   }
 }

--- a/src/RazorPagesProject.E2ETests/Fixtures/EdgeFixture.cs
+++ b/src/RazorPagesProject.E2ETests/Fixtures/EdgeFixture.cs
@@ -19,7 +19,10 @@ public class EdgeFixture : BrowserFixture
         opts.AddArguments("-inprivate");
 
         // Workaround for https://github.com/SeleniumHQ/selenium/issues/15340
-        opts.AddArgument("--edge-skip-compat-layer-relaunch");
+        if (Environment.GetEnvironmentVariable("CI") != "true")
+        {
+            opts.AddArgument("--edge-skip-compat-layer-relaunch");
+        }
 
         // Comment this out if you want to watch or interact with the browser (e.g. for debugging)
         if (!Debugger.IsAttached)

--- a/src/RazorPagesProject.E2ETests/Fixtures/EdgeFixture.cs
+++ b/src/RazorPagesProject.E2ETests/Fixtures/EdgeFixture.cs
@@ -18,6 +18,9 @@ public class EdgeFixture : BrowserFixture
 
         opts.AddArguments("-inprivate");
 
+        // Workaround for https://github.com/SeleniumHQ/selenium/issues/15340
+        opts.AddArgument("--edge-skip-compat-layer-relaunch");
+
         // Comment this out if you want to watch or interact with the browser (e.g. for debugging)
         if (!Debugger.IsAttached)
         {

--- a/src/RazorPagesProject/Properties/launchSettings.json
+++ b/src/RazorPagesProject/Properties/launchSettings.json
@@ -13,6 +13,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:7072;http://localhost:5016",
+      "launchUrl": "GithubProfile",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/RazorPagesProject/RazorPagesProject.csproj
+++ b/src/RazorPagesProject/RazorPagesProject.csproj
@@ -20,4 +20,27 @@
     </PackageReference>
   </ItemGroup>
 
+  <!-- The following target is a workaround for https://github.com/dotnet/aspnetcore/issues/59625 -->
+  <Target
+    Name="Workaround_ResolveBuildCompressedStaticWebAssetsConfiguration"
+    BeforeTargets="ResolveBuildCompressedStaticWebAssetsConfiguration">
+    <!-- Remove any duplicate items from StaticWebAssets -->
+
+    <ItemGroup>
+      <StaticWebAsset_NoDuplicates />
+    </ItemGroup>
+
+    <RemoveDuplicates Inputs="@(StaticWebAsset)">
+      <Output TaskParameter="Filtered" ItemName="StaticWebAsset_NoDuplicates" />
+    </RemoveDuplicates>
+
+    <ItemGroup>
+      <!-- Clear StaticWebAsset -->
+      <StaticWebAsset Remove="@(StaticWebAsset)" />
+
+      <!-- Copy filtered list to StaticWebAsset -->
+      <StaticWebAsset Include="@(StaticWebAsset_NoDuplicates)" />
+    </ItemGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
This pull request includes two main changes: upgrading the .NET SDK version and adding a workaround to address a known issue in the ASP.NET Core framework. Below are the details of these changes:

### SDK Upgrade:
* Updated the .NET SDK version in `global.json` from `9.0.201` to `9.0.300` to ensure the project uses the latest feature updates and improvements.

### Workaround for ASP.NET Core Issue:
* Added a new MSBuild target in `RazorPagesProject.csproj` to resolve duplicate entries in the `StaticWebAsset` item group. This is a temporary fix for [ASP.NET Core issue #59625](https://github.com/dotnet/aspnetcore/issues/59625). The target removes duplicates, clears the original `StaticWebAsset` group, and repopulates it with the filtered list.