### PR TITLE
feat: Implement error handling for non-existent GitHub users and upda…

### DIFF
--- a/src/RazorPagesProject.E2ETests/GithubProfilePageTest.cs
+++ b/src/RazorPagesProject.E2ETests/GithubProfilePageTest.cs
@@ -35,4 +35,20 @@ public class GithubProfilePageTest : IClassFixture<EdgeFixture>
         Assert.Equal("Microsoft GitHub User", _githubProfilePage.Name.Text);
         Assert.Equal("Microsoft", _githubProfilePage.Company.Text);
     }
+
+    [Fact]
+    public void Should_Show_Error_When_User_Not_Found()
+    {
+        // Arrange
+        var userName = "thisuserdoesnotexist1234567890";
+
+        // Act
+        _githubProfilePage.UserName.Clear();
+        _githubProfilePage.UserName.SendKeys(userName);
+        _githubProfilePage.ClickShowUserProfileButton();
+
+        // Assert
+        Assert.NotNull(_githubProfilePage.ErrorBanner);
+        Assert.Contains($"ユーザー '{userName}' は見つかりませんでした。", _githubProfilePage.ErrorBanner.Text);
+    }
 }

--- a/src/RazorPagesProject.E2ETests/PageObjects/GitHubProfilePage.cs
+++ b/src/RazorPagesProject.E2ETests/PageObjects/GitHubProfilePage.cs
@@ -9,6 +9,7 @@ public class GitHubProfilePage(IWebDriver driver, ITestOutputHelper? helper) : P
     public IWebElement Login => Driver.FindElement(By.Id("user-login"));
     public IWebElement Name => Driver.FindElement(By.Id("name"));
     public IWebElement Company => Driver.FindElement(By.Id("company"));
+    public IWebElement? ErrorBanner => Driver.FindElements(By.Id("error-banner")).FirstOrDefault();
 
     public GitHubProfilePage ClickShowUserProfileButton()
     {

--- a/src/RazorPagesProject/Pages/GithubProfile.cshtml
+++ b/src/RazorPagesProject/Pages/GithubProfile.cshtml
@@ -1,4 +1,4 @@
-@page "{userName?}"
+@page
 @model GithubProfileModel
 @{
     ViewData["Title"] = "GitHub Profile";
@@ -7,6 +7,14 @@
 <h1 class="page-title">
     <i class="fab fa-github me-2"></i>GitHub Profile Explorer
 </h1>
+
+@if (!string.IsNullOrEmpty(Model.ErrorMessage))
+{
+    <div class="alert alert-danger mb-3 alert-dismissible fade show" role="alert" id="error-banner">
+        @Model.ErrorMessage
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+}
 
 <div class="row">
     <div class="col-md-6 mb-4">
@@ -95,8 +103,11 @@
             const originalText = btn.innerHTML;
             btn.innerHTML = '<i class="fas fa-spinner fa-spin me-2"></i>読み込み中...';
             btn.disabled = true;
-
-            // フォーム送信は通常通り行われる
         });
+        // Bootstrapのalert-dismissible用（Bootstrap 5以降）
+        // 追加のJSは不要ですが、jQueryやBootstrap JSが読み込まれていない場合は下記で手動対応も可
+        // document.getElementById('error-banner')?.querySelector('.btn-close')?.addEventListener('click', function() {
+        //     document.getElementById('error-banner').style.display = 'none';
+        // });
     </script>
 }


### PR DESCRIPTION
…te UI to display error messages

This pull request introduces error handling for the GitHub profile search functionality, ensuring users receive appropriate feedback when a profile is not found. Key changes include updates to the Razor page, backend logic, and automated tests to support this new behavior.

### Error handling for GitHub profile search:

* [`src/RazorPagesProject/Pages/GithubProfile.cshtml.cs`](diffhunk://#diff-0bdccddbb0a35250e470e3d4cd86e4070a041753e2b2e55429e9212312b9906bL28-L34): Added an `ErrorMessage` property to display error messages when a user is not found. Updated the `OnGetAsync` method to handle `HttpRequestException` and set the error message accordingly. Modified the `OnPost` method to pass the username as a query parameter. [[1]](diffhunk://#diff-0bdccddbb0a35250e470e3d4cd86e4070a041753e2b2e55429e9212312b9906bL28-L34) [[2]](diffhunk://#diff-0bdccddbb0a35250e470e3d4cd86e4070a041753e2b2e55429e9212312b9906bL45-R60)

* [`src/RazorPagesProject/Pages/GithubProfile.cshtml`](diffhunk://#diff-787ac456963a6564ace4beb87ea97a753aa24fe403e3d6699dd4b42f065372ffR11-R18): Added an error banner to display the `ErrorMessage` when it is set. Updated the JavaScript to handle dismissible alerts for error messages. [[1]](diffhunk://#diff-787ac456963a6564ace4beb87ea97a753aa24fe403e3d6699dd4b42f065372ffR11-R18) [[2]](diffhunk://#diff-787ac456963a6564ace4beb87ea97a753aa24fe403e3d6699dd4b42f065372ffL98-R111)

### Test updates:

* [`src/RazorPagesProject.E2ETests/GithubProfilePageTest.cs`](diffhunk://#diff-371ffe1f5fd215b1ea9e474f45ac8131a885b59696917beec05510515d0bf85dR38-R53): Added a new test method, `Should_Show_Error_When_User_Not_Found`, to verify that an error banner is displayed when a nonexistent user is searched.

* [`src/RazorPagesProject.E2ETests/PageObjects/GitHubProfilePage.cs`](diffhunk://#diff-844ad55e4c35cdf6de6c7ca31973e91a7c9d56cc62e7e5a0fbab788c45065942R12): Introduced a new `ErrorBanner` property to access the error banner element in the test page object.

### Other adjustments:

* [`src/RazorPagesProject/Pages/GithubProfile.cshtml`](diffhunk://#diff-787ac456963a6564ace4beb87ea97a753aa24fe403e3d6699dd4b42f065372ffL1-R1): Removed the route parameter `{userName?}` from the Razor page, transitioning to query parameter usage for consistency.