### PR TITLE
feat: GitHubユーザーが見つからない場合のエラーメッセージを追加

### DIFF
--- a/src/RazorPagesProject/Pages/GithubProfile.cshtml
+++ b/src/RazorPagesProject/Pages/GithubProfile.cshtml
@@ -7,7 +7,13 @@
 <h1 class="page-title">
     <i class="fab fa-github me-2"></i>GitHub Profile Explorer
 </h1>
-
+@if (!string.IsNullOrEmpty(Model.ErrorMessage))
+{
+    <div id="error-banner" class="alert alert-danger alert-dismissible fade show mt-3" role="alert">
+        @Model.ErrorMessage
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+}
 <div class="row">
     <div class="col-md-6 mb-4">
         <div class="profile-card">
@@ -95,8 +101,7 @@
             const originalText = btn.innerHTML;
             btn.innerHTML = '<i class="fas fa-spinner fa-spin me-2"></i>読み込み中...';
             btn.disabled = true;
-
-            // フォーム送信は通常通り行われる
         });
+        // Bootstrapのalert-dismissibleは自動で閉じるので追加JSは不要
     </script>
 }

--- a/src/RazorPagesProject/Pages/GithubProfile.cshtml.cs
+++ b/src/RazorPagesProject/Pages/GithubProfile.cshtml.cs
@@ -25,13 +25,18 @@ public class GithubProfileModel : PageModel
 
     public GitHubUser? GithubUser { get; private set; }
 
+    public string? ErrorMessage { get; private set; }
+
     public async Task<IActionResult> OnGetAsync([FromRoute] string userName)
     {
         if (userName != null)
         {
             GithubUser = await Client.GetUserAsync(userName);
+            if (GithubUser == null)
+            {
+                ErrorMessage = $"ユーザー '{userName}' は見つかりませんでした。";
+            }
         }
-
         return Page();
     }
 

--- a/src/RazorPagesProject/Services/GithubClient.cs
+++ b/src/RazorPagesProject/Services/GithubClient.cs
@@ -6,19 +6,22 @@ public class GithubClient(HttpClient client) : IGithubClient
 {
     public HttpClient Client { get; } = client;
 
-    public async Task<GitHubUser> GetUserAsync(string userName)
+    public async Task<GitHubUser?> GetUserAsync(string userName)
     {
         var response = await Client.GetAsync($"/users/{Uri.EscapeDataString(userName)}");
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
         response.EnsureSuccessStatusCode();
-
         var user = await response.Content.ReadFromJsonAsync<GitHubUser>();
-        return user!;
+        return user;
     }
 }
 
 public interface IGithubClient
 {
-    Task<GitHubUser> GetUserAsync(string userName);
+    Task<GitHubUser?> GetUserAsync(string userName);
 }
 
 public class GitHubUser


### PR DESCRIPTION
This pull request enhances error handling and user feedback in the GitHub Profile Explorer feature. Key changes include adding error messages for non-existent GitHub users, updating the UI to display these messages, and modifying the `GithubClient` to handle `404 Not Found` responses gracefully.

### Error Handling Enhancements:

* Added an `ErrorMessage` property to the `InputModel` in `GithubProfile.cshtml.cs` to store error messages when a GitHub user is not found. Updated the `OnGetAsync` method to set this property if the user does not exist.
* Updated the `GithubClient` to return `null` instead of throwing an exception when a `404 Not Found` response is received. This change ensures smoother error handling for missing users. The `GetUserAsync` method now returns a nullable `GitHubUser`.

### User Interface Improvements:

* Modified `GithubProfile.cshtml` to display an error banner when the `ErrorMessage` property is set. This improves user feedback by showing a clear message when a GitHub user is not found.
* Added a comment in the JavaScript section of `GithubProfile.cshtml` explaining that no additional code is needed for dismissible alerts, as Bootstrap handles it automatically.