### PR TITLE
Bump SDK version to 9.0.301 in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.300",
+    "version": "9.0.301",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
This pull request updates the .NET SDK version in the `global.json` file to ensure compatibility with the latest feature updates.

* [`global.json`](diffhunk://#diff-8df3cd354bc584349d04ad5675b33c042d8b99b741b8b95af394c55e0f5001bfL3-R3): Updated the SDK version from `9.0.300` to `9.0.301` to align with the latest feature release.