### PR TITLE
Add devcontainers package-ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,10 @@
 version: 2
 updates:
-- package-ecosystem: nuget
+- package-ecosystem: dotnet-sdk
+  directory: "/"
+  schedule:
+    interval: daily
+- package-ecosystem: devcontainers
   directory: "/"
   schedule:
     interval: daily
@@ -8,7 +12,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-- package-ecosystem: dotnet-sdk
+- package-ecosystem: nuget
   directory: "/"
   schedule:
     interval: daily


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` file to reorganize and adjust the package ecosystems monitored by Dependabot. The most notable changes involve adding the `devcontainers` ecosystem.

Reorganization of package ecosystems:

* Added the `devcontainers` package ecosystem from the configuration.
* Switched `dotnet-sdk` back to `nuget` with its original configuration.