### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/sikebe-demo/dotnet-test-demo/security/code-scanning/4](https://github.com/sikebe-demo/dotnet-test-demo/security/code-scanning/4)

To resolve the issue, we need to add a `permissions` block to the workflow file. This block explicitly defines the permissions required by the workflow. Based on the tasks performed in the workflow (e.g., running tests, uploading artifacts), the permissions can be set to `contents: read`, which is the minimum required permission. This ensures the workflow does not inadvertently inherit elevated permissions from the repository.

The fix involves adding the following block at the root level of the workflow file:
```yaml
permissions:
  contents: read
```
This restricts the `GITHUB_TOKEN` permissions to read-only access to repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
