### PR TITLE
Add setup for Japanese font environment in CI workflow

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -29,3 +29,17 @@ jobs:
 
     - name: Build
       run: dotnet build
+
+    - name: Setup Japanese Font Environment
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          fonts-noto-cjk \
+          fonts-noto-cjk-extra \
+          fonts-liberation \
+          fonts-dejavu-core \
+          fontconfig
+        # フォントキャッシュを更新
+        sudo fc-cache -fv
+        # 利用可能な日本語フォントを確認
+        fc-list :lang=ja | head -10


### PR DESCRIPTION
This pull request adds a step to the GitHub Actions workflow to set up a Japanese font environment. This ensures proper rendering of Japanese text during the build or testing process.

* [`.github/workflows/copilot-setup-steps.yml`](diffhunk://#diff-98dad98422cf59793a353f9b6bfe6a129977e92af3d5b4e38f98ae45bcb7560dR32-R45): Added a new step to install Japanese fonts (`fonts-noto-cjk`, `fonts-noto-cjk-extra`, etc.), update the font cache, and verify available Japanese fonts.