### PR TITLE
Bump .NET SDK to 10.0.400 on stabilized E2E baseline

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.302",
+    "version": "10.0.400",
     "rollForward": "latestFeature"
   }
 }

--- a/src/RazorPagesProject.E2ETests/Fixtures/EdgeFixture.cs
+++ b/src/RazorPagesProject.E2ETests/Fixtures/EdgeFixture.cs
@@ -8,7 +8,10 @@ public class EdgeFixture : BrowserFixture
 {
     protected override IWebDriver CreateDriver()
     {
-        var opts = new EdgeOptions();
+        var opts = new EdgeOptions
+        {
+            PageLoadStrategy = PageLoadStrategy.Eager
+        };
 
         // Ignore self-signed certificate warnings
         opts.AddArgument("--ignore-certificate-errors");


### PR DESCRIPTION
## Summary
- bump the pinned .NET SDK from 10.0.302 to 10.0.400
- use Selenium's eager page-load strategy so E2E navigation does not wait indefinitely for external profile images

## Root cause
The failing Selenium session loaded profile data containing an external avatar image. Under Linux CI, Edge could remain blocked waiting for that resource, causing later `GoToUrl` commands to hit the WebDriver HTTP timeout. The tests already explicitly wait for required DOM elements, so `PageLoadStrategy.Eager` preserves their assertions while removing the unrelated external-resource dependency.

## Validation
- solution build passed with .NET SDK 10.0.400
- PrimeService unit tests: 12 passed
- Razor Pages integration tests: 14 passed
- Selenium E2E tests: 10 passed locally
- GitHub Actions CI and CodeQL passed

## Screenshots
Screenshots omitted because these changes only update the pinned SDK and E2E WebDriver loading behavior; they do not modify CSS, Razor templates, client assets, or any UI rendering path.