### PR TITLE
Upgrade projects to .NET 10

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,8 +19,7 @@
   },
   "features": {
     "ghcr.io/devcontainers/features/dotnet:2": {
-      "version": "9.0",
-      "additionalVersions": "8.0"
+      "version": "10.0"
     },
     "ghcr.io/devcontainers/features/node:2": {
       "nodeVersionFile": ".node-version"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 # Custom Coding Instructions
 
 ## プロジェクト概要
-このプロジェクトは .NET 9 を使用した C# プロジェクトで、以下のコンポーネントを含みます：
+このプロジェクトは .NET 10 を使用した C# プロジェクトで、以下のコンポーネントを含みます：
 * PrimeService: 素数判定ライブラリ
 * RazorPagesProject: ASP.NET Core Razor Pages Webアプリケーション
 * 各種テストプロジェクト（Unit Tests, Integration Tests, E2E Tests, Playwright Tests）
@@ -9,7 +9,7 @@
 ## コーディング規約
 
 ### 1. 全般的な規約
-* **言語バージョン**: C# 最新機能を活用（.NET 9 対応）
+* **言語バージョン**: C# 14 の最新機能を活用（.NET 10 対応）
 * **命名規則**: PascalCase（クラス、メソッド、プロパティ）、camelCase（ローカル変数、フィールド）
 * **ファイル構成**: 1クラス1ファイルの原則
 * **using文**: ファイルスコープのusingディレクティブを優先使用

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,4 +94,4 @@ jobs:
       if: failure()
       with:
         name: logs
-        path: src/RazorPagesProject.E2ETests/bin/Debug/net9.0/logs
+        path: src/RazorPagesProject.E2ETests/bin/Debug/net10.0/logs

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>
     <VersionPrefix>0.0.1</VersionPrefix>
     <DebugType>embedded</DebugType>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ dotnet-test-demo/
 
 ## 🛠️ Technologies & Frameworks
 
-- **.NET 9** - Latest .NET framework
+- **.NET 10 LTS** - Current long-term support .NET release
 - **ASP.NET Core** - Web framework
 - **Razor Pages** - Page-based web UI framework
 - **Entity Framework Core** - Object-relational mapping
@@ -40,7 +40,7 @@ dotnet-test-demo/
 
 ### Prerequisites
 
-- [.NET 9 SDK](https://dotnet.microsoft.com/download/dotnet/9.0) (version 9.0.301 or later)
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) (version 10.0.400 or later)
 - A code editor ([Visual Studio](https://visualstudio.microsoft.com/), [Visual Studio Code](https://code.visualstudio.com/), or [JetBrains Rider](https://www.jetbrains.com/rider/))
 
 ### Installation & Setup
@@ -141,7 +141,7 @@ dotnet test --collect:"XPlat Code Coverage"
 ## 🔧 Development Guidelines
 
 ### Code Quality Standards
-- **C# Latest Features**: Utilizes .NET 9 and C# preview features
+- **C# Latest Features**: Uses .NET 10 and stable C# 14 features
 - **SOLID Principles**: Clean architecture implementation
 - **Async/Await**: Proper asynchronous programming patterns
 - **Dependency Injection**: Constructor injection throughout

--- a/src/PrimeService.Tests/PrimeService.Tests.csproj
+++ b/src/PrimeService.Tests/PrimeService.Tests.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/PrimeService/PrimeService.csproj
+++ b/src/PrimeService/PrimeService.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/RazorPagesProject.E2ETests/RazorPagesProject.E2ETests.csproj
+++ b/src/RazorPagesProject.E2ETests/RazorPagesProject.E2ETests.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.47.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/src/RazorPagesProject.IntegrationTests/RazorPagesProject.IntegrationTests.csproj
+++ b/src/RazorPagesProject.IntegrationTests/RazorPagesProject.IntegrationTests.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.7.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.19" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.19" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/RazorPagesProject/Program.cs
+++ b/src/RazorPagesProject/Program.cs
@@ -65,13 +65,13 @@ else
     app.UseHttpsRedirection();
 }
 
-app.UseStaticFiles();
-
 app.UseRequestLocalization();
 
 app.UseRouting();
 app.UseAuthorization();
-app.MapRazorPages();
+app.MapStaticAssets();
+app.MapRazorPages()
+    .WithStaticAssets();
 app.Run();
 
 static void SeedDatabase(WebApplication app)

--- a/src/RazorPagesProject/README.md
+++ b/src/RazorPagesProject/README.md
@@ -4,7 +4,7 @@ ASP.NET Core Razor Pages application demonstrating modern web development practi
 
 ## Features
 
-* ASP.NET Core 9.0 Razor Pages
+* ASP.NET Core 10.0 Razor Pages
 * Entity Framework Core with SQLite
 * ASP.NET Core Identity for authentication
 * Internationalization (i18n) support
@@ -15,7 +15,7 @@ ASP.NET Core Razor Pages application demonstrating modern web development practi
 
 ### Prerequisites
 
-- .NET 9.0 SDK
+- .NET 10.0 SDK
 - Node.js and npm (for client-side dependencies)
 
 ### Setup

--- a/src/RazorPagesProject/RazorPagesProject.csproj
+++ b/src/RazorPagesProject/RazorPagesProject.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <UserSecretsId>aspnet-RazorPagesProject-2f32791e-bf2b-47ae-869d-b4fe5e5981da</UserSecretsId>
   </PropertyGroup>
 
@@ -10,37 +10,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.19" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.19" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.19" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.19" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
-  <!-- The following target is a workaround for https://github.com/dotnet/aspnetcore/issues/59625 -->
-  <Target
-    Name="Workaround_ResolveBuildCompressedStaticWebAssetsConfiguration"
-    BeforeTargets="ResolveBuildCompressedStaticWebAssetsConfiguration">
-    <!-- Remove any duplicate items from StaticWebAssets -->
-
-    <ItemGroup>
-      <StaticWebAsset_NoDuplicates />
-    </ItemGroup>
-
-    <RemoveDuplicates Inputs="@(StaticWebAsset)">
-      <Output TaskParameter="Filtered" ItemName="StaticWebAsset_NoDuplicates" />
-    </RemoveDuplicates>
-
-    <ItemGroup>
-      <!-- Clear StaticWebAsset -->
-      <StaticWebAsset Remove="@(StaticWebAsset)" />
-
-      <!-- Copy filtered list to StaticWebAsset -->
-      <StaticWebAsset Include="@(StaticWebAsset_NoDuplicates)" />
-    </ItemGroup>
-  </Target>
 
 </Project>


### PR DESCRIPTION
## Why

Move the solution from .NET 9 to the .NET 10 LTS release and align the application, test infrastructure, CI, and development environment with the supported .NET 10 toolchain.

## What changed

- Retarget all five projects to `net10.0` and use stable C# 14.
- Align ASP.NET Core and EF Core packages on `10.0.11`, including integration-test dependencies and the EF CLI tool.
- Update the test SDK to `18.9.0`.
- Adopt the recommended `MapStaticAssets` and `WithStaticAssets` endpoint-based static asset pipeline.
- Remove the obsolete .NET 9 static web assets workaround after its SDK issue was fixed.
- Update the dev container, CI artifact paths, repository guidance, and documentation for .NET 10.

The EF Core 10 breaking changes for multi-targeting, SQL Server JSON mappings, and complex types do not apply to this single-target SQLite model. No model snapshot changes or new migrations are required.

## Validation

- Release build completed without warnings.
- 12 unit tests, 14 integration tests, and 10 E2E tests passed on `net10.0`.
- The Razor Pages app and static assets returned HTTP 200.
- EF Core reported no pending model changes.
- Web publish and PrimeService package creation completed.
- NuGet vulnerability audit reported no vulnerable direct or transitive packages.

## Screenshots

Screenshots omitted because no Razor templates, styles, layout, copy, or rendered UI behavior changed. The static asset change only replaces the serving implementation, and the existing E2E suite covers the rendered pages.

## References

- https://learn.microsoft.com/aspnet/core/migration/90-to-100
- https://learn.microsoft.com/ef/core/what-is-new/ef-core-10.0/breaking-changes
- https://learn.microsoft.com/dotnet/csharp/whats-new/csharp-14